### PR TITLE
Revising readme for schematics 2-zone vpc template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,59 @@
-# 2-Zone VPC template
+# Two-zone Virtual Private Cloud
 
-The 2-Zone VPC template is an IBM Cloud Schematics template that is used to create two virtual private clouds (VPCs), each in a different zone. A user-specified number of virtual machines is created in each VPC and loaded with NGINX. Schematics uses [Terraform](https://www.terraform.io/) as the infrastructure-as-code engine. With this template, you can create and manage infrastructure as a single unit.
+With this template, you can use IBM Cloud Schematics to create two virtual private clouds (VPCs) in two separate zones of your IBM Cloud account. Schematics uses [Terraform](https://www.terraform.io/) as the infrastructure-as-code engine. With this template, you can create and manage infrastructure as a single unit as follows. For more information about how to use this template, see the [IBM Cloud Schematics documentation](https://cloud.ibm.com/docs/schematics).
 
-For more information about how to use this template, see the [IBM Cloud Schematics documentation](https://cloud.ibm.com/docs/schematics).
+**Included**:
+* 2 [virtual private cloud](https://cloud.ibm.com/docs/vpc-on-classic?topic=vpc-on-classic-getting-started) instances, in separate zones.
+* As many [VPC virtual servers](https://cloud.ibm.com/docs/vpc-on-classic-vsi?topic=vpc-on-classic-vsi-getting-started) as you specify. The virtual servers include an NGINX load balancer.
 
-**Note**: This template doesn't install load balancers within the VPCs or a global load balancer for traffic management across VPCs.
+**Not included**:
+* No VPC load balancers are created to expose workloads in the virtual servers on the public network. 
+* No global load balancer is provisioned to manage traffic across the 2 VPC instances.
 
 ## Costs
 
-This sample uses chargeable services, and you are charged for the time the services are deployed. Running the `terraform destroy` command deletes all resources.
+When you apply template, the infrastructure resources that you create incur charges as follows. To clean up the resources, you can [delete your Schematics workspace or your instance](https://cloud.ibm.com/docs/schematics?topic=schematics-manage-lifecycle#destroy-resources). Removing the workspace or the instance cannot be undone. Make sure that you back up any data that you must keep before you start the deletion process. 
+
+* **VPC**: VPC charges are incurred for the infrastructure resources within the VPC, as well as network traffic for internet data transfer. For more information, see [Pricing for VPC](https://cloud.ibm.com/docs/vpc-on-classic?topic=vpc-on-classic-pricing-for-vpc).
+* **VPC virtual servers**: You specify how many virtual servers to provision in each VPC. The price for your virtual server instances depends on the flavor of the instances, how many you provision, and how long the instances are run. For more information, see [Pricing for Virtual Servers for VPC](https://cloud.ibm.com/docs/infrastructure/vpc-on-classic?topic=vpc-on-classic-pricing-for-vpc#pricing-for-virtual-servers-for-vpc).
 
 ## Dependencies
 
-The user must have Identity and Access Management (IAM) access to create and configure VPCs and VSIs.
+Before you can apply the template in IBM Cloud, complete the following steps.
+
+1.  Make sure that you have the following permissions in IBM Cloud Identity and Access Management: 
+    * **Manager** service access role for IBM Cloud Schematics
+    * **Operator** platform role for VPC Infrastructure
+2.  Store your credentials in an [IBM Cloud API key](https://cloud.ibm.com/iam/apikeys). Note the API key value that you use later for the `ibmcloud_api_key` variable.
+3.  Download the [`ibmcloud` command line interface (CLI) tool](https://cloud.ibm.com/docs/cli/reference/ibmcloud?topic=cloud-cli-install-ibmcloud-cli).
+4.  Install the `ibmcloud terraform` and `ibmcloud is` CLI plug-ins for Schematics and VPC infrastructure. **Tip**: To update your current plug-ins, run `ibmcloud plugin update`.
+    *  `ibmcloud plugin install schematics`
+    *  `ibmcloud plugin install vpc-infrastructure`
+5.  [Create or use an existing SSH key for VPC virtual servers](https://cloud.ibm.com/docs/vpc-on-classic-vsi?topic=vpc-on-classic-vsi-ssh-keys).
 
 ## Configuring your deployment values
 
-Create or retrieve the following variable before you use the template: 
+When you select the [`2-zone-vpc`template](https://cloud.ibm.com/catalog/content/2-zone-vpc) from the IBM Cloud catalog, you set up your deployment variables from the **Create** page. When you apply the template, IBM Cloud Schematics provisions the resources according to the values that you specify for these variables.
 
-* `ibmcloud_api_key` is your IBM Cloud API key. Go to the [IBM Cloud API keys page](https://cloud.ibm.com/iam/apikeys) to create one.
+### Required values
+Fill in the following values, based on the steps that you completed before you began.
 
-You must also set the following deployment values on the Create page. You can enter customized values or accept the defaults.
+|Variable Name|Description|
+|-------------|-----------|
+|`ibmcloud_api_key`|Enter the [IBM Cloud API key](https://cloud.ibm.com/docs/iam?topic=iam-userapikey) with the appropriate permissions to Schematics and VPC infrastructure.|
+|`ssh_public_key`|Enter the [public SSH key](https://cloud.ibm.com/docs/vpc-on-classic-vsi?topic=vpc-on-classic-vsi-ssh-keys) that you use to access your VPC virtual servers. The public key is saved to an `id_rsa.pub` file in the `.ssh` subdirectory of your home directory.|
+
+### Optional values
+Before you apply your template, you can customize the following default variable values.
 
 |Variable Name|Description|Default Value|
 |-------------|-----------|-------------|
-|region|Region for deploying VPC, for example, us-east. To get a list of all regions, run the `ic is regions` command.|us-east|
-|ssh_public_key|Your public key that is saved to a `id_rsa.pub` file in the `.ssh` subdirectory of your home directory.||
-|ssh_key_name|Name of SSH key|VPC_ssh_key|
-|num_vms_per_VPC|Number of virtual machines to create per VPC|1|
-|image|Virtual machine image identifier. To get a list of all images, run the `ic is images` command.|7eb4e35b-4257-56f8-d7da-326d85452591|
-|profile|Virtual machine CPU profile. To get a list of all instance profiles, run the `ic is instance-profiles` command.|b-2x8|
+|`region`|The region to create your two VPCs in, such as `us-south`. The VPCs are created in two separate zones within the same region. To get a list of all regions, run `ibmcloud is regions`.|`us-south`|
+|`ssh_key_name`|The name of your public SSH key.|`VPC_ssh_key`|
+|`num_vms_per_VPC`|Specify the number of virtual servers to create in each VPC.|`1`|
+|`image`|Enter the ID of the image that represents the operating system that you want to install on your VPC virtual server. To list available images, run `ibmcloud is images`. The default image is for an `ubuntu-16.04-amd64` OS.|`7eb4e35b-4257-56f8-d7da-326d85452591`|
+|`profile`|Enter the profile of compute CPU and memory resources that you want your VPC virtual servers to have. To list available profiles, run `ibmcloud is instance-profiles`.|`bc1-2x8`|
 
 
 ## Outputs
-
-The log section `Terraform SHOW` lists all the IPs and identifiers to access the VPCs.
+After you apply the template your VPC resources are successfully provisioned in IBM Cloud, you can review information such as the virtual server IP addresses and VPC identifiers in the Schamtics log files, in the `Terraform SHOW` section.

--- a/provider.tf
+++ b/provider.tf
@@ -1,11 +1,11 @@
 
 variable "ibmcloud_api_key" {
-  description = "Your IBM Cloud API key. If you need to create one, go to the [IBM Cloud API keys page](https://cloud.ibm.com/iam/apikeys)."
+  description = "The [IBM Cloud API key](https://cloud.ibm.com/docs/iam?topic=iam-userapikey) with the appropriate permissions to Schematics and VPC infrastructure."
 }
 
 variable "region" {
-  description = "Region for deploying VPC, for example, us-east. To get a list of all regions, run the `ic is regions` command."
-  default = "us-east"
+  description = "The region to create your two VPCs in, such as `us-south`. The VPCs are created in two separate zones within the same region. To get a list of all regions, run `ic is regions`."
+  default = "us-south"
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -1,25 +1,25 @@
 
 variable "ssh_public_key" {
   default = ""
-  description = "Your public key, which is saved to a `id_rsa.pub` file in the `.ssh` subdirectory of your home directory."
+  description = "The [public SSH key](https://cloud.ibm.com/docs/vpc-on-classic-vsi?topic=vpc-on-classic-vsi-ssh-keys) that you use to access your VPC virtual servers. The public key is saved to an `id_rsa.pub` file in the `.ssh` subdirectory of your home directory."
 }
 
 variable "ssh_key_name" {
   default = "VPC_ssh_key"
-  description = "The name of the SSH key"
+  description = "The name of the public SSH key."
 }
 
 variable "num_vms_per_VPC" {
   default = 1
-  description = "Number of virtual machines to create per virtual private cloud"
+  description = "The number of virtual servers to create in each VPC."
 }
 
 variable "image" {
   default = "7eb4e35b-4257-56f8-d7da-326d85452591"
-  description = "Virtual machine image identifier. To get a list of all images, run the `ic is images` command."
+  description = "The ID of the image that represents the operating system that you want to install on your VPC virtual server. To list available images, run `ibmcloud is images`. The default image is for an `ubuntu-16.04-amd64` OS."
 }
 
 variable "profile" {
-  default = "b-2x8"
-  description = "Virtual machine CPU profile. To get a list of all instance profiles, run the `ic is instance-profiles` command."
+  default = "bc1-2x8"
+  description = The profile of compute CPU and memory resources that you want your VPC virtual servers to have. To list available profiles, run `ibmcloud is instance-profiles`."
 }


### PR DESCRIPTION
Also updated following default values based on what's in VPC prod today:
* region `us-east` changed to `us-south`
* profile `b-2x8` changed to `bc1-2x8`